### PR TITLE
Add CI, linting, tests, docs & CLI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+
+jobs:
+  quality:
+    name: Quality Gates
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm --filter hyperiux test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run quality gates
+        run: |
+          pnpm lint
+          pnpm --filter hyperiux test
+
+      - name: Publish with provenance
+        run: pnpm --filter hyperiux publish --provenance --no-git-checks --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.1] - 2026-06-03
+
+### Fixed
+- Hardcoded `src/` path alias bug: CLI now dynamically checks for layout directory structure at runtime.
+- Target path prefix mismatch: aligned registry matching (`components/hyperiux/`) with registry builder outputs.
+- Dynamic `cssPath` resolution: CSS default location now fallbacks properly depending on `src/` existence.
+
+### Added
+- Shell command execution validation: regex verification (`/^[a-z0-9-@/_.]+$/`) on package dependencies to block command injection.
+- Complete ESLint configurations and Flat Config rules for `packages/cli`.
+- Automated test coverage: unit tests for configuration, registry mapping, and package manager sanitizers using Vitest.
+- GitHub Actions CI/CD workflows for automated PR gates and package release builds.
+
+## [0.1.0] - 2026-06-01
+
+### Added
+- Initial release of the `hyperiux` CLI command utility.
+- Commands: `init`, `add`, `list` to fetch and import components from remote effect registry.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Hyperiux
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/changes.txt
+++ b/changes.txt
@@ -1,0 +1,78 @@
+CHANGES LOG - HYPERIUX CLI & PACKAGING (PRODUCTION READY)
+
+===================================================================
+1. CORE BUG FIXES & SECURITY HARDENING (CLI UTILITY)
+===================================================================
+
+[MODIFIED] packages/cli/src/utils/config.js
+  - Replaced hardcoded 'src/' target folder mappings.
+  - Dynamically detects the presence of a root 'src/' directory in the consumer project.
+  - Generates correct paths depending on the workspace structure.
+
+[MODIFIED] packages/cli/src/utils/registry.js
+  - Fixed path alias translation by checking for 'components/hyperiux/' registry prefixes.
+  - Restored configuration mapping so custom aliases (e.g. aliases.effects in hyperiux.json) are respected.
+  - Dynamically prepends 'src/' layout prefix to target paths only when 'src/' directory is detected.
+
+[MODIFIED] packages/cli/src/utils/package-manager.js
+  - Added strict regex sanitization checking for dependency package installations: /^[a-z0-9-@/_.]+$/
+  - Blocks command injection and execution of malicious code if remote registry files are compromised.
+
+[MODIFIED] packages/cli/src/commands/init.js
+  - Dynamically creates configuration templates using detected layout values.
+  - Fallbacks default global CSS search to 'app/globals.css' if 'src/' is not present.
+
+[MODIFIED] packages/cli/src/commands/add.js
+  - Passes execution directory context to registry mapping functions.
+  - Corrects import path resolver replacement rules using safe string start regex rules (^src/).
+
+===================================================================
+2. LINTING & QUALITY GATES
+===================================================================
+
+[MODIFIED] packages/cli/package.json
+  - Added 'eslint' and 'vitest' to devDependencies list.
+  - Added run scripts for 'lint', 'test', and 'test:coverage'.
+
+[CREATED] packages/cli/eslint.config.js
+  - Set up Flat ESLint rules configuration.
+  - Added read-only globals for Node environment and 'fetch' APIs.
+
+===================================================================
+3. AUTOMATED TESTING
+===================================================================
+
+[CREATED] packages/cli/vitest.config.js
+  - Added Vitest runner configurations.
+
+[CREATED] packages/cli/src/tests/config.test.js
+  - Wrote 8 unit tests validating layout prefixing and directory settings.
+
+[CREATED] packages/cli/src/tests/registry.test.js
+  - Wrote 2 unit tests verifying path translations to custom aliases.
+
+[CREATED] packages/cli/src/tests/package-manager.test.js
+  - Wrote 3 unit tests verifying package sanitization, operator blocks, and execution control.
+
+===================================================================
+4. LEGAL, METADATA, & CI/CD PIPELINES
+===================================================================
+
+[CREATED] LICENSE
+  - Added root level MIT license copy.
+
+[CREATED] CHANGELOG.md
+  - Added root level release logs documenting initial 0.1.0 and fixed 0.1.1 versions.
+
+[CREATED] .github/workflows/ci.yml
+  - Added GitHub Actions pipeline to run lint checks and testing matrices on pushes/PRs.
+
+[CREATED] .github/workflows/release.yml
+  - Added release script pipeline to automate npm publishes with cryptographic provenance badges.
+
+===================================================================
+5. VERIFICATION DASHBOARD
+===================================================================
+
+[CREATED] preview.html
+  - Interactive HTML preview page displaying full audits, checklists, and test result outputs.

--- a/npm-package-agency-sop.md
+++ b/npm-package-agency-sop.md
@@ -1,0 +1,216 @@
+# npm Package Agency SOP
+
+> Standard Operating Procedure for delivering a production-ready npm package.
+> Owner: Engineering Lead | Updated: June 2026
+> Apply this document to every package delivered by or accepted from a vendor.
+
+---
+
+## Part 1 — Acceptance Criteria (Pass/Fail)
+
+A package is only accepted when ALL items below are PASS.
+Any single FAIL blocks milestone payment.
+
+### Functional correctness
+
+| # | Test | Method | Pass condition |
+|---|---|---|---|
+| F1 | ESM import works | `node --input-type=module --eval 'import { X } from "pkg"; console.log(typeof X)'` | Prints `function` or `object` |
+| F2 | CJS require works | `node -e "const p = require('pkg'); console.log(Object.keys(p))"` | Prints array of exported names |
+| F3 | TypeScript resolves types | `tsc --noEmit --moduleResolution bundler --strict` with one import | Zero errors |
+| F4 | Subpath imports work | Same as F1/F2 for each documented subpath | All pass |
+| F5 | No duplicate peer installed | `npm ls react` in consumer project | Exactly one version |
+
+### Build quality
+
+| # | Test | Method | Pass condition |
+|---|---|---|---|
+| B1 | `dist/` contains required files | `ls dist/esm/ dist/cjs/ dist/types/` | All three directories exist |
+| B2 | Declaration files present | `wc -l dist/types/index.d.ts` | > 10 lines |
+| B3 | Source maps present | `ls dist/**/*.map` | At least one exists |
+| B4 | Build is reproducible | Run build twice, `git diff dist/` | Empty diff |
+| B5 | Tarball is clean | `npm pack --dry-run` output | No `src/`, `tests/`, `.env`, or config files |
+| B6 | Bundle size in limit | `npx size-limit` | Under defined limit (default 50 kB gzipped) |
+
+### Quality gates
+
+| # | Test | Method | Pass condition |
+|---|---|---|---|
+| Q1 | Lint passes | `npm run lint` | Exit code 0, zero warnings |
+| Q2 | Type-check passes | `npm run type-check` | Exit code 0, zero errors |
+| Q3 | Tests pass | `npm test` | 100% of tests pass |
+| Q4 | Coverage meets threshold | `npm run test:coverage` | ≥ 80% lines, ≥ 80% functions |
+| Q5 | Type tests pass | `tsc -p tsconfig.test.json --noEmit` | Exit code 0 |
+
+### Security
+
+| # | Test | Method | Pass condition |
+|---|---|---|---|
+| S1 | No HIGH/CRITICAL vulnerabilities | `npm audit --audit-level=high` | Exit code 0 |
+| S2 | No secrets in tarball | Manual grep on packed tarball | Zero matches |
+| S3 | No GPL dependencies | `npx license-checker --failOn "GPL;AGPL"` | Exit code 0 |
+| S4 | No risky install scripts | Check `package.json` scripts | No `preinstall`, `install`, `postinstall` |
+
+### Documentation
+
+| # | Check | Method | Pass condition |
+|---|---|---|---|
+| D1 | README has quick start | Manual review | Working code example present |
+| D2 | README has API reference | Manual review | Prop/param table present for each export |
+| D3 | README has TypeScript example | Manual review | `import type` example present |
+| D4 | CHANGELOG.md exists | `ls CHANGELOG.md` | File exists and documents current version |
+| D5 | LICENSE file exists | `ls LICENSE` | File present, matches `package.json` license field |
+
+### npm metadata
+
+| # | Check | Method | Pass condition |
+|---|---|---|---|
+| M1 | Scoped name | `npm view pkg name` | Name starts with `@scope/` |
+| M2 | License declared | `npm view pkg license` | Valid SPDX identifier |
+| M3 | Repository link works | Open URL in browser | GitHub or equivalent page loads |
+| M4 | Provenance badge | npmjs.com listing | Provenance section visible |
+| M5 | Description is meaningful | `npm view pkg description` | Not blank, not "TODO", ≥ 10 words |
+
+---
+
+## Part 2 — Mandatory CI Checks
+
+These jobs must run on every PR and every release branch.
+
+### `ci.yml` — Copy-paste ready
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+
+jobs:
+  quality:
+    name: Quality Gates
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version:[1][2][3]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Clean install
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type-check
+        run: npm run type-check
+
+      - name: Unit tests
+        run: npm run test
+
+      - name: Coverage check
+        run: npm run test:coverage
+
+      - name: Build
+        run: npm run build
+
+      - name: Bundle size check
+        run: npm run size
+
+      - name: Inspect tarball
+        run: npm pack --dry-run
+
+  security:
+    name: Security Gates
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Vulnerability audit
+        run: npm audit --audit-level=high
+
+      - name: License check
+        run: npx license-checker --failOn "GPL;AGPL"
+
+      - name: Secret scan
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          head: HEAD
+```
+
+### `release.yml` — Copy-paste ready
+
+```yaml
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      - name: Clean install
+        run: npm ci
+
+      - name: Run all quality gates
+        run: |
+          npm run lint
+          npm run type-check
+          npm run test
+          npm run build
+          npm run size
+
+      - name: Security audit
+        run: npm audit --audit-level=high
+
+      - name: Publish with provenance
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Verify published package
+        run: |
+          sleep 10
+          npm view ${{ env.PACKAGE_NAME }} version
+```
+
+---
+
+## Part 3 — Publish Checklist
+
+Print and sign off before every release.

--- a/npm-package-release-checklist.md
+++ b/npm-package-release-checklist.md
@@ -1,0 +1,256 @@
+# npm Package Release Checklist
+
+> Run this checklist before every npm publish — patch, minor, or major.
+> Version: 1.0.0 | Updated: June 2026
+
+---
+
+## Stage 1 — Pre-Build Verification
+
+Run locally before touching the build.
+
+```bash
+# 1. Start from a clean state
+git status                    # must be clean, no uncommitted changes
+git pull origin main          # must be up to date
+
+# 2. Clean install
+rm -rf node_modules
+npm ci
+
+# 3. Security audit
+npm audit --audit-level=high  # MUST pass — zero HIGH or CRITICAL issues
+
+# 4. Outdated check
+npm outdated                  # Review and decide on updates
+```
+
+- [ ] Git working tree is clean
+- [ ] `npm ci` completes without errors
+- [ ] `npm audit --audit-level=high` reports zero HIGH or CRITICAL issues
+- [ ] No abandoned or suspicious packages in dependency tree
+
+---
+
+## Stage 2 — Quality Gates
+
+```bash
+# 5. Lint — zero warnings allowed
+npm run lint
+
+# 6. Type-check — zero errors allowed
+npm run type-check
+
+# 7. Tests — must pass 100%
+npm run test
+
+# 8. Coverage — must meet threshold
+npm run test:coverage
+```
+
+- [ ] Lint passes with zero warnings
+- [ ] TypeScript type-check passes with zero errors
+- [ ] All unit tests pass
+- [ ] All integration tests pass
+- [ ] Coverage meets declared thresholds (recommended: 80% lines, 80% functions, 70% branches)
+- [ ] Type tests pass (`tsc -p tsconfig.test.json --noEmit`)
+
+---
+
+## Stage 3 — Build Verification
+
+```bash
+# 9. Build from clean
+npm run build
+
+# 10. Verify dist output exists and is non-trivial
+ls -lah dist/
+wc -l dist/esm/index.js       # Must be > 10 lines
+wc -l dist/types/index.d.ts   # Must be > 10 lines
+
+# 11. Verify no peer dependencies bundled
+grep -l "react" dist/esm/index.js   # Should NOT contain react source
+
+# 12. Verify reproducibility
+npm run build
+git diff dist/               # Should be empty (no diff from same source)
+```
+
+- [ ] `dist/esm/index.js` exists and is non-trivial
+- [ ] `dist/cjs/index.cjs` exists and is non-trivial
+- [ ] `dist/types/index.d.ts` exists and is non-trivial
+- [ ] Source maps exist: `dist/**/*.map`
+- [ ] Build is reproducible (no diff on second clean build)
+- [ ] No peer dependencies (react, vue, etc.) present in bundled output
+
+---
+
+## Stage 4 — Tarball Inspection
+
+```bash
+# 13. Inspect tarball contents
+npm pack --dry-run
+
+# 14. Verify only intended files are included
+# Expected: dist/, README.md, CHANGELOG.md, LICENSE, package.json
+# NOT expected: src/, tests/, .env, *.config.*, node_modules/
+
+# 15. Check for accidentally published secrets
+npm pack
+tar -tf *.tgz
+grep -r "API_KEY\|SECRET\|TOKEN\|PASSWORD" $(npm pack --dry-run 2>&1 | grep -v npm)
+rm *.tgz   # clean up after inspection
+```
+
+- [ ] `npm pack --dry-run` shows only: `dist/`, `README.md`, `CHANGELOG.md`, `LICENSE`
+- [ ] No `src/` directory in tarball
+- [ ] No `tests/` directory in tarball
+- [ ] No `.env` files in tarball
+- [ ] No config files (`.eslintrc`, `tsconfig.json`, `vite.config.ts`) in tarball
+- [ ] No secrets, tokens, or API keys anywhere in tarball
+
+---
+
+## Stage 5 — Consumer Import Test
+
+Create a temp directory and test a real install from the tarball.
+
+```bash
+# 16. Pack
+npm pack
+# Produces: your-package-1.0.0.tgz
+
+# 17. Create clean consumer
+mkdir /tmp/pkg-test && cd /tmp/pkg-test
+npm init -y
+npm install /path/to/your-package-1.0.0.tgz react react-dom
+
+# 18. Test ESM import
+node --input-type=module --eval \
+  'import { Button } from "your-package"; console.log(typeof Button)'
+# Expected output: function
+
+# 19. Test CJS import
+node -e "const p = require('your-package'); console.log(Object.keys(p))"
+# Expected output: array of exported names
+
+# 20. Test TypeScript resolution
+echo 'import { Button } from "your-package"' > test.ts
+npx tsc --noEmit --moduleResolution bundler --module esnext --strict test.ts
+# Expected: no errors
+
+# 21. Clean up
+cd ~ && rm -rf /tmp/pkg-test
+```
+
+- [ ] ESM named import resolves and exports are functions/objects
+- [ ] CJS require resolves and exports are correct
+- [ ] TypeScript resolves types without errors
+- [ ] Subpath imports work if documented (e.g., `from "pkg/tokens"`)
+- [ ] No duplicate peer dependency installed inside package (check: `npm ls react`)
+
+---
+
+## Stage 6 — Version and Changelog
+
+```bash
+# 22. Bump version
+# Patch: bug fixes only
+npm version patch
+
+# Minor: new features, backwards compatible
+npm version minor
+
+# Major: breaking changes
+npm version major
+
+# 23. Update CHANGELOG.md before tagging
+```
+
+- [ ] Version bump follows semver rules correctly
+- [ ] `CHANGELOG.md` updated with all changes for this version
+- [ ] Breaking changes are explicitly documented
+- [ ] Migration guide written for major versions
+- [ ] Git tag created: `git tag v1.0.0`
+
+---
+
+## Stage 7 — Publish
+
+```bash
+# 24. Final publish (prepublishOnly will re-run all gates)
+npm publish --access public
+
+# With provenance (strongly recommended, requires CI)
+npm publish --provenance --access public
+```
+
+- [ ] `prepublishOnly` script ran and passed
+- [ ] Published from CI, not from a local laptop (strongly recommended)
+- [ ] npm 2FA confirmed on maintainer account
+- [ ] Provenance flag used
+- [ ] Verify live on npm: `npm view @your-scope/package-name`
+
+---
+
+## Stage 8 — Post-Publish Verification
+
+```bash
+# 25. Verify the published package resolves
+npm view @your-scope/package-name
+
+# 26. Fresh install in a new project
+mkdir /tmp/post-publish-test && cd /tmp/post-publish-test
+npm init -y
+npm install @your-scope/package-name
+node -e "console.log(require('@your-scope/package-name'))"
+
+# 27. Clean up
+cd ~ && rm -rf /tmp/post-publish-test
+```
+
+- [ ] `npm view` shows correct version, description, and license
+- [ ] Fresh install from registry works
+- [ ] Import from installed registry version works
+- [ ] npmjs.com listing shows correct README
+- [ ] npmjs.com listing shows provenance badge
+
+---
+
+## Rollback Plan
+
+If a broken version was published:
+
+```bash
+# Deprecate the broken version immediately
+npm deprecate @your-scope/package-name@"1.0.1" \
+  "Broken release — do not use. Upgrade to 1.0.2."
+
+# Publish a fix as a new patch
+npm version patch
+npm publish --access public
+
+# Only unpublish within 72 hours if absolutely necessary
+npm unpublish @your-scope/package-name@"1.0.1" --force
+```
+
+- [ ] Broken version deprecated with a clear message
+- [ ] Patch release published
+- [ ] Users notified via GitHub issue or release notes
+
+---
+
+## Quick Reference — Command Summary
+
+```bash
+git status && git pull origin main
+rm -rf node_modules && npm ci
+npm audit --audit-level=high
+npm run lint
+npm run type-check
+npm run test
+npm run build
+npm pack --dry-run
+npm publish --provenance --access public
+npm view @your-scope/package-name
+```

--- a/npm-package-security-checklist.md
+++ b/npm-package-security-checklist.md
@@ -1,0 +1,305 @@
+# npm Package Security Checklist
+
+> Run before every publish. No exceptions.
+> Version: 1.0.0 | Updated: June 2026
+
+---
+
+## 1) Dependency Vulnerability Audit
+
+```bash
+# Run full audit
+npm audit
+
+# Block on high and critical only (recommended for CI)
+npm audit --audit-level=high
+
+# Auto-fix safe remediations
+npm audit fix
+
+# Review what cannot be auto-fixed
+npm audit fix --dry-run
+```
+
+### Pass/Fail criteria
+
+| Severity | Policy |
+|---|---|
+| Critical | ❌ BLOCK publish immediately |
+| High | ❌ BLOCK publish immediately |
+| Moderate | ⚠️ Document and plan fix within 30 days |
+| Low | ℹ️ Track; fix in next scheduled update |
+
+- [ ] Zero CRITICAL vulnerabilities
+- [ ] Zero HIGH vulnerabilities
+- [ ] All MODERATE vulnerabilities documented with remediation plan
+
+---
+
+## 2) Dependency Reputation Check
+
+Before adding any new dependency, verify:
+
+```bash
+# Check package age, download count, last publish
+npm view <package-name>
+
+# Check for known issues
+npm audit <package-name>
+
+# Check license
+npx license-checker --summary
+```
+
+### Red flags for any dependency
+
+- [ ] Last published more than 2 years ago with open security issues
+- [ ] Fewer than 1,000 weekly downloads with no major adopters
+- [ ] No `repository` field in its own `package.json`
+- [ ] Contains a `postinstall` or `preinstall` script
+- [ ] Owner account has published only 1–2 packages
+- [ ] Name is suspiciously close to a popular package (typosquatting)
+
+---
+
+## 3) Install Script Risk
+
+Install scripts (`preinstall`, `install`, `postinstall`) execute code on the consumer's machine at install time. They are a primary attack vector.
+
+```bash
+# Check your own package
+cat package.json | grep -A 10 '"scripts"'
+
+# Check all dependencies for install scripts
+npm ls --depth=1 | xargs -I{} sh -c \
+  'cat node_modules/{}/package.json 2>/dev/null | grep -l "postinstall\|preinstall"'
+```
+
+- [ ] Your package has NO `preinstall`, `install`, or `postinstall` scripts
+- [ ] If install scripts are required, they are documented and audited
+- [ ] No direct dependencies run undocumented shell commands on install
+
+---
+
+## 4) Secret and Credential Exposure
+
+The most damaging security incident for an npm package: accidentally publishing API keys, tokens, or credentials.
+
+```bash
+# Check for common secret patterns in your source
+grep -rn \
+  "API_KEY\|SECRET\|TOKEN\|PASSWORD\|PRIVATE_KEY\|AWS_\|DATABASE_URL" \
+  src/ --include="*.ts" --include="*.js"
+
+# Check what will actually be published
+npm pack --dry-run
+
+# Unpack and scan the tarball
+npm pack
+mkdir /tmp/tarball-scan && cd /tmp/tarball-scan
+tar -xf /path/to/your-package-*.tgz
+grep -rn "API_KEY\|SECRET\|TOKEN\|PASSWORD\|PRIVATE_KEY" package/
+cd ~ && rm -rf /tmp/tarball-scan && rm /path/to/your-package-*.tgz
+```
+
+### Files that must NEVER be published
+
+- `.env`, `.env.local`, `.env.production`
+- `*.pem`, `*.key`, `*.p12`
+- `config/secrets.*`
+- `credentials.json`
+- `.npmrc` containing auth tokens
+- Any file with hardcoded credentials
+
+```bash
+# Add to .npmignore (or control via "files" in package.json — preferred)
+.env*
+*.pem
+*.key
+*.p12
+.npmrc
+config/secrets.*
+```
+
+- [ ] No secrets found in source files
+- [ ] No secrets found in tarball
+- [ ] `.env` files are in `.gitignore` AND `.npmignore`
+- [ ] No hardcoded tokens in any configuration file
+
+---
+
+## 5) Code Execution Risk
+
+These patterns are dangerous in npm packages because they can execute arbitrary code at runtime.
+
+```bash
+# Scan for dangerous patterns
+grep -rn \
+  "eval(\|new Function(\|child_process\|execSync\|exec(\|spawn(\|__dirname.*require\|path.join.*require" \
+  src/ --include="*.ts" --include="*.js"
+```
+
+### Risk classification
+
+| Pattern | Risk | Action |
+|---|---|---|
+| `eval(userInput)` | Critical | Replace with safe alternative |
+| `new Function(userInput)` | Critical | Replace with safe alternative |
+| `child_process.exec(userInput)` | Critical | Sanitize all inputs |
+| `require(dynamicVariable)` | High | Replace with static imports |
+| `fs.readFile(userPath)` | Medium | Validate and sanitize path |
+| `JSON.parse(userInput)` | Low | Wrap in try/catch |
+
+- [ ] No `eval()` with external input
+- [ ] No `new Function()` with external input
+- [ ] No shell command execution with unsanitized input
+- [ ] No dynamic `require()` with user-controlled paths
+- [ ] No path traversal risk in file operations
+
+---
+
+## 6) Prototype Pollution Risk
+
+Especially relevant for packages that merge, extend, or deep-copy objects.
+
+```bash
+# Scan for risky patterns
+grep -rn \
+  "__proto__\|constructor\[.prototype.\]\|Object.assign\|merge(\|deepMerge(" \
+  src/ --include="*.ts" --include="*.js"
+```
+
+### Safe merge pattern
+
+```ts
+// UNSAFE
+function merge(target: any, source: any) {
+  for (const key in source) {
+    target[key] = source[key];  // __proto__ can be set here
+  }
+}
+
+// SAFE
+function merge<T extends object>(target: T, source: Partial<T>): T {
+  const safeKeys = Object.keys(source).filter(
+    key => key !== "__proto__" && key !== "constructor" && key !== "prototype"
+  );
+  return Object.assign({}, target, Object.fromEntries(
+    safeKeys.map(k => [k, (source as any)[k]])
+  )) as T;
+}
+```
+
+- [ ] No object merge operations vulnerable to prototype pollution
+- [ ] User-controlled keys are validated before use as object properties
+
+---
+
+## 7) Publishing Account Security
+
+```bash
+# Check who can publish this package
+npm owner ls @your-scope/package-name
+
+# Verify 2FA is enabled (do this in browser at npmjs.com/settings)
+# Require 2FA for publish:
+npm profile set auth-and-writes --otp=<your-otp>
+```
+
+- [ ] npm account has 2FA enabled (auth-and-writes mode)
+- [ ] Only authorized team members are listed as package owners
+- [ ] Publishing tokens are scoped to publish-only (not read-write-admin)
+- [ ] Publishing tokens are stored in CI secrets, not in code or dotfiles
+- [ ] No publishing tokens in `.npmrc` committed to the repository
+
+---
+
+## 8) npm Provenance
+
+Provenance cryptographically links a published package to the CI workflow that created it, so consumers can verify the package matches source code.
+
+```yaml
+# .github/workflows/release.yml
+- name: Publish to npm
+  run: npm publish --provenance --access public
+  env:
+    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+# Required permissions block
+permissions:
+  id-token: write
+  contents: read
+```
+
+- [ ] Provenance enabled in `publishConfig`: `{ "provenance": true }`
+- [ ] Publish step uses `--provenance` flag
+- [ ] GitHub Actions has `id-token: write` permission
+- [ ] npmjs.com listing shows the provenance badge after publish
+
+---
+
+## 9) License and Third-Party Risk
+
+```bash
+# Check all dependency licenses
+npx license-checker --summary
+
+# Check for GPL/AGPL (incompatible with proprietary use)
+npx license-checker --failOn "GPL;AGPL"
+```
+
+### License compatibility
+
+| Dependency license | Risk for proprietary package |
+|---|---|
+| MIT, ISC, BSD-2, BSD-3 | ✅ Safe |
+| Apache-2.0 | ✅ Safe with notice |
+| LGPL | ⚠️ Review required |
+| GPL, AGPL | ❌ Incompatible — do not use |
+| UNLICENSED | ❌ Do not use |
+
+- [ ] Zero GPL or AGPL dependencies
+- [ ] No UNLICENSED dependencies
+- [ ] `THIRD_PARTY_LICENSES.md` generated and committed
+
+---
+
+## 10) CI Security Gates
+
+Every CI pipeline for an npm package must enforce these checks automatically.
+
+```yaml
+# Minimum required security jobs in CI
+- name: Security audit
+  run: npm audit --audit-level=high
+
+- name: License check
+  run: npx license-checker --failOn "GPL;AGPL"
+
+- name: Secret scan
+  uses: trufflesecurity/trufflehog@main
+  with:
+    path: ./
+    base: main
+    head: HEAD
+```
+
+- [ ] `npm audit --audit-level=high` runs on every PR
+- [ ] License check runs on every PR
+- [ ] Secret scanning runs on every PR (TruffleHog, GitLeaks, or equivalent)
+- [ ] CI blocks merge if any security check fails
+- [ ] Dependency review runs on `package-lock.json` changes
+
+---
+
+## Quick Reference — Security Commands
+
+```bash
+npm audit --audit-level=high
+npm outdated
+npx license-checker --summary
+npx license-checker --failOn "GPL;AGPL"
+npm pack --dry-run
+grep -rn "API_KEY\|SECRET\|TOKEN" src/
+npm owner ls @your-scope/package-name
+```

--- a/packages/cli/eslint.config.js
+++ b/packages/cli/eslint.config.js
@@ -1,0 +1,21 @@
+import js from "@eslint/js";
+
+export default [
+  js.configs.recommended,
+  {
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      globals: {
+        process: "readonly",
+        console: "readonly",
+        __dirname: "readonly",
+        fetch: "readonly"
+      }
+    },
+    rules: {
+      "no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
+      "no-undef": "error"
+    }
+  }
+];

--- a/packages/cli/node_modules/.bin/eslint
+++ b/packages/cli/node_modules/.bin/eslint
@@ -1,0 +1,17 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -z "$NODE_PATH" ]; then
+  export NODE_PATH="/Users/dikshayadav/Code/hyperiux-components/node_modules/.pnpm/eslint@9.39.4_jiti@2.7.0/node_modules/eslint/bin/node_modules:/Users/dikshayadav/Code/hyperiux-components/node_modules/.pnpm/eslint@9.39.4_jiti@2.7.0/node_modules/eslint/node_modules:/Users/dikshayadav/Code/hyperiux-components/node_modules/.pnpm/eslint@9.39.4_jiti@2.7.0/node_modules:/Users/dikshayadav/Code/hyperiux-components/node_modules/.pnpm/node_modules"
+else
+  export NODE_PATH="/Users/dikshayadav/Code/hyperiux-components/node_modules/.pnpm/eslint@9.39.4_jiti@2.7.0/node_modules/eslint/bin/node_modules:/Users/dikshayadav/Code/hyperiux-components/node_modules/.pnpm/eslint@9.39.4_jiti@2.7.0/node_modules/eslint/node_modules:/Users/dikshayadav/Code/hyperiux-components/node_modules/.pnpm/eslint@9.39.4_jiti@2.7.0/node_modules:/Users/dikshayadav/Code/hyperiux-components/node_modules/.pnpm/node_modules:$NODE_PATH"
+fi
+if [ -x "$basedir/node" ]; then
+  exec "$basedir/node"  "$basedir/../eslint/bin/eslint.js" "$@"
+else
+  exec node  "$basedir/../eslint/bin/eslint.js" "$@"
+fi

--- a/packages/cli/node_modules/.bin/vitest
+++ b/packages/cli/node_modules/.bin/vitest
@@ -1,0 +1,17 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -z "$NODE_PATH" ]; then
+  export NODE_PATH="/Users/dikshayadav/Code/hyperiux-components/node_modules/.pnpm/vitest@4.1.8_@opentelemetry+api@1.9.1_@types+node@25.9.1_vite@8.0.16_@types+node@25.9.1_jiti@2.7.0_/node_modules/vitest/node_modules:/Users/dikshayadav/Code/hyperiux-components/node_modules/.pnpm/vitest@4.1.8_@opentelemetry+api@1.9.1_@types+node@25.9.1_vite@8.0.16_@types+node@25.9.1_jiti@2.7.0_/node_modules:/Users/dikshayadav/Code/hyperiux-components/node_modules/.pnpm/node_modules"
+else
+  export NODE_PATH="/Users/dikshayadav/Code/hyperiux-components/node_modules/.pnpm/vitest@4.1.8_@opentelemetry+api@1.9.1_@types+node@25.9.1_vite@8.0.16_@types+node@25.9.1_jiti@2.7.0_/node_modules/vitest/node_modules:/Users/dikshayadav/Code/hyperiux-components/node_modules/.pnpm/vitest@4.1.8_@opentelemetry+api@1.9.1_@types+node@25.9.1_vite@8.0.16_@types+node@25.9.1_jiti@2.7.0_/node_modules:/Users/dikshayadav/Code/hyperiux-components/node_modules/.pnpm/node_modules:$NODE_PATH"
+fi
+if [ -x "$basedir/node" ]; then
+  exec "$basedir/node"  "$basedir/../vitest/vitest.mjs" "$@"
+else
+  exec node  "$basedir/../vitest/vitest.mjs" "$@"
+fi

--- a/packages/cli/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/packages/cli/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,0 +1,1 @@
+{"version":"4.1.8","results":[[":src/tests/config.test.js",{"duration":2.447082999999992,"failed":false}],[":src/tests/package-manager.test.js",{"duration":2.276833999999994,"failed":false}],[":src/tests/registry.test.js",{"duration":1.7953329999999994,"failed":false}]]}

--- a/packages/cli/node_modules/eslint
+++ b/packages/cli/node_modules/eslint
@@ -1,0 +1,1 @@
+../../../node_modules/.pnpm/eslint@9.39.4_jiti@2.7.0/node_modules/eslint

--- a/packages/cli/node_modules/vitest
+++ b/packages/cli/node_modules/vitest
@@ -1,0 +1,1 @@
+../../../node_modules/.pnpm/vitest@4.1.8_@opentelemetry+api@1.9.1_@types+node@25.9.1_vite@8.0.16_@types+node@25.9.1_jiti@2.7.0_/node_modules/vitest

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,7 +11,9 @@
   ],
   "scripts": {
     "build": "echo 'No build step required'",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "chalk": "^5.4.1",
@@ -46,5 +48,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "eslint": "^9",
+    "vitest": "^4.1.8"
   }
 }

--- a/packages/cli/src/commands/add.js
+++ b/packages/cli/src/commands/add.js
@@ -37,7 +37,7 @@ export async function add(effectName, options) {
   }
 
   // Get files to install
-  const files = getRegistryItemFiles(registryItem, config);
+  const files = getRegistryItemFiles(registryItem, config, cwd);
 
   // Check for existing files
   const existingFiles = files.filter((f) =>
@@ -154,14 +154,15 @@ export async function add(effectName, options) {
 
 function getImportPath(file, config) {
   const targetPath = file.targetPath;
-  const effectsPath = config.aliases?.effects || "@/components/effects";
+  const effectsAlias = config.aliases?.effects || "@/components/effects";
+  const effectsPath = effectsAlias.replace("@/", "");
 
-  if (targetPath.includes("components/effects/")) {
+  if (targetPath.includes(effectsPath)) {
     const fileName = path.basename(targetPath, ".jsx");
-    return `${effectsPath}/${fileName}`;
+    return `${effectsAlias}/${fileName}`;
   }
 
-  return `@/${targetPath.replace("src/", "").replace(".jsx", "")}`;
+  return `@/${targetPath.replace(/^src\//, "").replace(".jsx", "")}`;
 }
 
 function getComponentName(effectName) {

--- a/packages/cli/src/commands/init.js
+++ b/packages/cli/src/commands/init.js
@@ -81,10 +81,13 @@ export async function init(options) {
     // Write config file
     writeConfig(config, cwd);
 
+    const usesSrc = fs.existsSync(path.join(cwd, "src"));
+    const prefix = usesSrc ? "src/" : "";
+
     // Create directories if they don't exist
-    const effectsDir = path.join(cwd, config.aliases.effects.replace("@/", "src/"));
-    const hooksDir = path.join(cwd, config.aliases.hooks.replace("@/", "src/"));
-    const libDir = path.join(cwd, config.aliases.lib.replace("@/", "src/"));
+    const effectsDir = path.join(cwd, config.aliases.effects.replace("@/", prefix));
+    const hooksDir = path.join(cwd, config.aliases.hooks.replace("@/", prefix));
+    const libDir = path.join(cwd, config.aliases.lib.replace("@/", prefix));
 
     ensureDir(effectsDir);
     ensureDir(hooksDir);
@@ -119,7 +122,8 @@ function detectCssPath(cwd) {
     }
   }
 
-  return "src/app/globals.css";
+  const usesSrc = fs.existsSync(path.join(cwd, "src"));
+  return usesSrc ? "src/app/globals.css" : "app/globals.css";
 }
 
 function detectTailwindConfig(cwd) {

--- a/packages/cli/src/tests/config.test.js
+++ b/packages/cli/src/tests/config.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import { resolveAlias, getEffectsPath, getHooksPath, getLibPath } from "../utils/config.js";
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      existsSync: vi.fn(),
+    },
+    existsSync: vi.fn(),
+  };
+});
+
+describe("config utilities", () => {
+  const mockConfig = {
+    aliases: {
+      components: "@/components",
+      effects: "@/components/effects",
+      hooks: "@/hooks",
+      lib: "@/lib",
+    },
+  };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("when src/ directory exists", () => {
+    beforeEach(() => {
+      vi.mocked(fs.existsSync).mockImplementation((p) => {
+        if (p.endsWith("src")) return true;
+        return false;
+      });
+    });
+
+    it("should resolve aliases with src/ prefix", () => {
+      const result = resolveAlias("@/components/effects/blur-text", mockConfig);
+      expect(result).toBe("src/components/effects/blur-text");
+    });
+
+    it("should fallback getEffectsPath to src/components/effects", () => {
+      expect(getEffectsPath(mockConfig)).toBe("src/components/effects");
+    });
+
+    it("should fallback getHooksPath to src/hooks", () => {
+      expect(getHooksPath(mockConfig)).toBe("src/hooks");
+    });
+
+    it("should fallback getLibPath to src/lib", () => {
+      expect(getLibPath(mockConfig)).toBe("src/lib");
+    });
+  });
+
+  describe("when src/ directory does NOT exist", () => {
+    beforeEach(() => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+    });
+
+    it("should resolve aliases without src/ prefix", () => {
+      const result = resolveAlias("@/components/effects/blur-text", mockConfig);
+      expect(result).toBe("components/effects/blur-text");
+    });
+
+    it("should fallback getEffectsPath to components/effects", () => {
+      expect(getEffectsPath(mockConfig)).toBe("components/effects");
+    });
+
+    it("should fallback getHooksPath to hooks", () => {
+      expect(getHooksPath(mockConfig)).toBe("hooks");
+    });
+
+    it("should fallback getLibPath to lib", () => {
+      expect(getLibPath(mockConfig)).toBe("lib");
+    });
+  });
+});

--- a/packages/cli/src/tests/package-manager.test.js
+++ b/packages/cli/src/tests/package-manager.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { installDependencies } from "../utils/package-manager.js";
+import { execSync } from "child_process";
+
+vi.mock("child_process", () => ({
+  execSync: vi.fn(),
+}));
+
+describe("package manager utilities", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should allow valid package names and call execSync", () => {
+    const result = installDependencies(["framer-motion", "gsap", "@types/react"]);
+    
+    expect(result.command).toContain("framer-motion gsap @types/react");
+    expect(execSync).toHaveBeenCalled();
+  });
+
+  it("should block package names containing malicious shell script characters", () => {
+    expect(() => {
+      installDependencies(["framer-motion; echo 'HACKED'"]);
+    }).toThrow("Invalid package name(s) detected");
+    
+    expect(execSync).not.toHaveBeenCalled();
+  });
+
+  it("should block package names containing backticks or shell operators", () => {
+    expect(() => {
+      installDependencies(["framer-motion && rm -rf /"]);
+    }).toThrow("Invalid package name(s) detected");
+    
+    expect(() => {
+      installDependencies(["framer-motion`id`"]);
+    }).toThrow("Invalid package name(s) detected");
+
+    expect(execSync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/tests/registry.test.js
+++ b/packages/cli/src/tests/registry.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import { getRegistryItemFiles } from "../utils/registry.js";
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      existsSync: vi.fn(),
+    },
+    existsSync: vi.fn(),
+  };
+});
+
+describe("registry utilities", () => {
+  const mockConfig = {
+    aliases: {
+      components: "@/components",
+      effects: "@/components/effects",
+      hooks: "@/hooks",
+      lib: "@/lib",
+    },
+  };
+
+  const mockItem = {
+    name: "blur-text",
+    files: [
+      {
+        path: "blur-text.jsx",
+        type: "registry:component",
+        target: "components/hyperiux/blur-text.jsx",
+      },
+      {
+        path: "use-animation.js",
+        type: "registry:component",
+        target: "hooks/use-animation.js",
+      },
+    ],
+  };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("when src/ directory exists", () => {
+    beforeEach(() => {
+      vi.mocked(fs.existsSync).mockImplementation((p) => {
+        if (p.endsWith("src")) return true;
+        return false;
+      });
+    });
+
+    it("should resolve components/hyperiux/ to custom effects alias and prepend src/", () => {
+      const files = getRegistryItemFiles(mockItem, mockConfig);
+      
+      expect(files[0].targetPath).toBe("src/components/effects/blur-text.jsx");
+      expect(files[1].targetPath).toBe("src/hooks/use-animation.js");
+    });
+  });
+
+  describe("when src/ directory does NOT exist", () => {
+    beforeEach(() => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+    });
+
+    it("should resolve components/hyperiux/ to custom effects alias and NOT prepend src/", () => {
+      const files = getRegistryItemFiles(mockItem, mockConfig);
+      
+      expect(files[0].targetPath).toBe("components/effects/blur-text.jsx");
+      expect(files[1].targetPath).toBe("hooks/use-animation.js");
+    });
+  });
+});

--- a/packages/cli/src/utils/config.js
+++ b/packages/cli/src/utils/config.js
@@ -43,27 +43,35 @@ export function getDefaultConfig() {
   return { ...DEFAULT_CONFIG };
 }
 
-export function resolveAlias(alias, config) {
+export function resolveAlias(alias, config, cwd = process.cwd()) {
+  const usesSrc = fs.existsSync(path.join(cwd, "src"));
+  const prefix = usesSrc ? "src/" : "";
   const aliasMap = config.aliases || {};
   for (const [key, value] of Object.entries(aliasMap)) {
     if (alias.startsWith(`@/${key}`)) {
-      return alias.replace(`@/${key}`, value.replace("@/", "src/"));
+      return alias.replace(`@/${key}`, value.replace("@/", prefix));
     }
   }
-  return alias.replace("@/", "src/");
+  return alias.replace("@/", prefix);
 }
 
-export function getEffectsPath(config) {
+export function getEffectsPath(config, cwd = process.cwd()) {
+  const usesSrc = fs.existsSync(path.join(cwd, "src"));
+  const prefix = usesSrc ? "src/" : "";
   const effectsAlias = config.aliases?.effects || "@/components/effects";
-  return effectsAlias.replace("@/", "src/");
+  return effectsAlias.replace("@/", prefix);
 }
 
-export function getHooksPath(config) {
+export function getHooksPath(config, cwd = process.cwd()) {
+  const usesSrc = fs.existsSync(path.join(cwd, "src"));
+  const prefix = usesSrc ? "src/" : "";
   const hooksAlias = config.aliases?.hooks || "@/hooks";
-  return hooksAlias.replace("@/", "src/");
+  return hooksAlias.replace("@/", prefix);
 }
 
-export function getLibPath(config) {
+export function getLibPath(config, cwd = process.cwd()) {
+  const usesSrc = fs.existsSync(path.join(cwd, "src"));
+  const prefix = usesSrc ? "src/" : "";
   const libAlias = config.aliases?.lib || "@/lib";
-  return libAlias.replace("@/", "src/");
+  return libAlias.replace("@/", prefix);
 }

--- a/packages/cli/src/utils/package-manager.js
+++ b/packages/cli/src/utils/package-manager.js
@@ -37,8 +37,17 @@ export function getInstallCommand(packageManager, packages) {
   }
 }
 
+const VALID_PACKAGE_NAME_REGEX = /^[a-z0-9-@/_.]+$/;
+
 export function installDependencies(packages, options = {}) {
   const { cwd = process.cwd(), dryRun = false } = options;
+
+  // Sanitize package names to prevent command injection
+  const invalidPackages = packages.filter((pkg) => !VALID_PACKAGE_NAME_REGEX.test(pkg));
+  if (invalidPackages.length > 0) {
+    throw new Error(`Invalid package name(s) detected: ${invalidPackages.join(", ")}`);
+  }
+
   const packageManager = detectPackageManager(cwd);
   const command = getInstallCommand(packageManager, packages);
 

--- a/packages/cli/src/utils/registry.js
+++ b/packages/cli/src/utils/registry.js
@@ -113,12 +113,18 @@ async function fetchRemoteRegistryIndex() {
   }
 }
 
-export function getRegistryItemFiles(item, config) {
+export function getRegistryItemFiles(item, config, cwd = process.cwd()) {
+  const usesSrc = fs.existsSync(path.join(cwd, "src"));
+  const prefix = usesSrc ? "src/" : "";
+
   return item.files.map((file) => {
     let targetPath = file.target;
 
     // Replace alias with actual path
-    if (targetPath.startsWith("components/effects/")) {
+    if (targetPath.startsWith("components/hyperiux/")) {
+      const effectsPath = config.aliases?.effects?.replace("@/", "") || "components/effects";
+      targetPath = targetPath.replace("components/hyperiux/", `${effectsPath}/`);
+    } else if (targetPath.startsWith("components/effects/")) {
       const effectsPath = config.aliases?.effects?.replace("@/", "") || "components/effects";
       targetPath = targetPath.replace("components/effects/", `${effectsPath}/`);
     } else if (targetPath.startsWith("hooks/")) {
@@ -131,7 +137,7 @@ export function getRegistryItemFiles(item, config) {
 
     return {
       ...file,
-      targetPath: `src/${targetPath}`,
+      targetPath: `${prefix}${targetPath}`,
     };
   });
 }

--- a/packages/cli/vitest.config.js
+++ b/packages/cli/vitest.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/tests/**/*.test.js"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,13 @@ importers:
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
+    devDependencies:
+      eslint:
+        specifier: ^9
+        version: 9.39.4(jiti@2.7.0)
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
 
 packages:
 
@@ -753,6 +760,9 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
+  '@oxc-project/types@0.133.0':
+    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
   '@prisma/instrumentation@7.6.0':
     resolution: {integrity: sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==}
     peerDependencies:
@@ -1052,6 +1062,98 @@ packages:
       react: ^19
       three: '>=0.159.0'
 
+  '@rolldown/binding-android-arm64@1.0.3':
+    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.3':
+    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@rollup/plugin-commonjs@28.0.1':
     resolution: {integrity: sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA==}
     engines: {node: '>=16.0.0 || 14 >= 14.17'}
@@ -1341,6 +1443,9 @@ packages:
     peerDependencies:
       webpack: '>=5.0.0'
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@stitches/react@1.2.8':
     resolution: {integrity: sha512-9g9dWI4gsSVe8bNLlb+lMkBYsnIKCZTmvqvDG+Avnn69XfmHZKiaMrx7cgTaddq7aTPPmXiTsbFcUy0xgI4+wA==}
     peerDependencies:
@@ -1473,8 +1578,14 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/draco3d@1.4.10':
     resolution: {integrity: sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==}
@@ -1736,6 +1847,35 @@ packages:
       vue-router:
         optional: true
 
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+
   '@webassemblyjs/ast@1.9.0':
     resolution: {integrity: sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==}
 
@@ -1922,6 +2062,10 @@ packages:
   assert@1.5.1:
     resolution: {integrity: sha512-zzw1uCAgLbsKwBfFc8CX78DDg+xZeBksSO3vwVIDDN5i94eOrPsSSyiVhmsSABFDM/OcpE2aagCat9dnWQLG1A==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   assign-symbols@1.0.0:
     resolution: {integrity: sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==}
     engines: {node: '>=0.10.0'}
@@ -2091,6 +2235,10 @@ packages:
 
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -2380,6 +2528,9 @@ packages:
     resolution: {integrity: sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -2531,6 +2682,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2545,6 +2699,10 @@ packages:
   expand-brackets@2.1.4:
     resolution: {integrity: sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -3583,6 +3741,9 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -3671,6 +3832,9 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pbkdf2@3.1.5:
     resolution: {integrity: sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==}
@@ -3946,6 +4110,11 @@ packages:
     resolution: {integrity: sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==}
     engines: {node: '>= 0.8'}
 
+  rolldown@1.0.3:
+    resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rollup@4.60.4:
     resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -4053,6 +4222,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -4112,6 +4284,9 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stacktrace-parser@0.1.11:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
@@ -4128,6 +4303,9 @@ packages:
 
   stats.js@0.17.0:
     resolution: {integrity: sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -4274,9 +4452,24 @@ packages:
     resolution: {integrity: sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==}
     engines: {node: '>=0.6.0'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-arraybuffer@1.0.1:
     resolution: {integrity: sha512-okFlQcoGTi4LQBG/PgSYblw9VOyptsz2KJZqc6qtgGdes8VktzUQkj4BI2blit072iS8VODNcMA+tvnS9dnuMA==}
@@ -4455,6 +4648,90 @@ packages:
     resolution: {integrity: sha512-SFlpdqZCjbNiV5RSel2Dvg0L49kSfeapn6SAJwMV/WCGvuYtqlSPWylTU35igGK5bAT1/Pu8QByKaAtALODJDw==}
     engines: {node: '>=6.4.0'}
 
+  vite@8.0.16:
+    resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vm-browserify@1.1.2:
     resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
 
@@ -4511,6 +4788,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -5264,6 +5546,8 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
 
+  '@oxc-project/types@0.133.0': {}
+
   '@prisma/instrumentation@7.6.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -5535,6 +5819,57 @@ snapshots:
       suspend-react: 0.1.3(react@19.2.6)
       three: 0.183.2
       three-stdlib: 2.36.1(three@0.183.2)
+
+  '@rolldown/binding-android-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/plugin-commonjs@28.0.1(rollup@4.60.4)':
     dependencies:
@@ -5820,6 +6155,8 @@ snapshots:
       - encoding
       - supports-color
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@stitches/react@1.2.8(react@19.2.6)':
     dependencies:
       react: 19.2.6
@@ -5922,9 +6259,16 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 25.9.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/draco3d@1.4.10': {}
 
@@ -6157,6 +6501,47 @@ snapshots:
     optionalDependencies:
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
+
+  '@vitest/expect@4.1.8':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)
+
+  '@vitest/pretty-format@4.1.8':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.8':
+    dependencies:
+      '@vitest/utils': 4.1.8
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.8': {}
+
+  '@vitest/utils@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@webassemblyjs/ast@1.9.0':
     dependencies:
@@ -6407,6 +6792,8 @@ snapshots:
       object.assign: 4.1.7
       util: 0.10.4
 
+  assertion-error@2.0.1: {}
+
   assign-symbols@1.0.0: {}
 
   ast-types-flow@0.0.8: {}
@@ -6622,6 +7009,8 @@ snapshots:
       three: 0.183.2
 
   caniuse-lite@1.0.30001793: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -7018,6 +7407,8 @@ snapshots:
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
 
+  es-module-lexer@2.1.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -7255,6 +7646,10 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   events@3.3.0: {}
@@ -7275,6 +7670,8 @@ snapshots:
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
+
+  expect-type@1.3.0: {}
 
   extend-shallow@2.0.1:
     dependencies:
@@ -8355,6 +8752,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obug@2.1.1: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -8451,6 +8850,8 @@ snapshots:
     dependencies:
       lru-cache: 11.5.0
       minipass: 7.1.3
+
+  pathe@2.0.3: {}
 
   pbkdf2@3.1.5:
     dependencies:
@@ -8733,6 +9134,27 @@ snapshots:
       hash-base: 3.1.2
       inherits: 2.0.4
 
+  rolldown@1.0.3:
+    dependencies:
+      '@oxc-project/types': 0.133.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.3
+      '@rolldown/binding-darwin-arm64': 1.0.3
+      '@rolldown/binding-darwin-x64': 1.0.3
+      '@rolldown/binding-freebsd-x64': 1.0.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
+      '@rolldown/binding-linux-arm64-gnu': 1.0.3
+      '@rolldown/binding-linux-arm64-musl': 1.0.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.3
+      '@rolldown/binding-linux-s390x-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-musl': 1.0.3
+      '@rolldown/binding-openharmony-arm64': 1.0.3
+      '@rolldown/binding-wasm32-wasi': 1.0.3
+      '@rolldown/binding-win32-arm64-msvc': 1.0.3
+      '@rolldown/binding-win32-x64-msvc': 1.0.3
+
   rollup@4.60.4:
     dependencies:
       '@types/estree': 1.0.8
@@ -8920,6 +9342,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
@@ -8982,6 +9406,8 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  stackback@0.0.2: {}
+
   stacktrace-parser@0.1.11:
     dependencies:
       type-fest: 0.7.1
@@ -8997,6 +9423,8 @@ snapshots:
       three: 0.183.2
 
   stats.js@0.17.0: {}
+
+  std-env@4.1.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -9173,10 +9601,21 @@ snapshots:
     dependencies:
       setimmediate: 1.0.5
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   to-arraybuffer@1.0.1: {}
 
@@ -9408,6 +9847,46 @@ snapshots:
 
   vecn@1.3.1: {}
 
+  vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.9.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 25.9.1
+    transitivePeerDependencies:
+      - msw
+
   vm-browserify@1.1.2: {}
 
   watchpack-chokidar2@2.0.1:
@@ -9515,6 +9994,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
Add GitHub Actions CI and release workflows; introduce ESLint flat config and Vitest runner. Add unit tests for config, registry, and package-manager, plus vitest/ESLint tooling and test results. Add documentation and governance files (CHANGELOG, LICENSE, release/security/release checklists, SOP). Update packages/cli: add lint/test scripts and devDependencies, sanitize install inputs with a strict package-name regex, dynamically detect presence of src/ when resolving aliases and generating target paths, fix registry alias mappings (components/hyperiux → effects alias) and import path resolution, and adjust init command to use detected layout and CSS fallback. Several test and tooling artifacts were added to validate these changes.