### PR TITLE
Fix: CLI completely broken - restore missing getFileContent export

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,7 @@
     "scripts/smoke-packed-package.mjs"
   ],
   "scripts": {
-    "build": "node --check src/index.js && node --check src/commands/add.js && node --check src/commands/init.js && node --check src/commands/list.js && node --check src/commands/login.js && node --check src/commands/logout.js && node --check src/commands/whoami.js && node --check src/utils/auth.js && node --check src/utils/config.js && node --check src/utils/package-manager.js && node --check src/utils/registry.js && node --check src/utils/telemetry.js",
+    "build": "node --check src/index.js && node --check src/commands/add.js && node --check src/commands/init.js && node --check src/commands/list.js && node --check src/commands/login.js && node --check src/commands/logout.js && node --check src/commands/whoami.js && node --check src/commands/diff.js && node --check src/commands/outdated.js && node --check src/commands/versions.js && node --check src/utils/auth.js && node --check src/utils/config.js && node --check src/utils/package-manager.js && node --check src/utils/registry.js && node --check src/utils/telemetry.js",
     "lint": "eslint src",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -31,6 +31,7 @@
   "dependencies": {
     "chalk": "^5.4.1",
     "commander": "^13.1.0",
+    "diff": "^9.0.0",
     "ora": "^8.1.1",
     "prompts": "^2.4.2"
   },

--- a/packages/cli/src/commands/add.js
+++ b/packages/cli/src/commands/add.js
@@ -4,7 +4,6 @@
 
 import fs from "fs";
 import path from "path";
-import { Buffer } from "buffer";
 import chalk from "chalk";
 import ora from "ora";
 import prompts from "prompts";
@@ -18,7 +17,7 @@ import {
 } from "../utils/config.js";
 import {
   fetchRegistry,
-  fetchRegistryAsset,
+  getFileContent,
   getRegistryItemFiles,
 } from "../utils/registry.js";
 import {
@@ -132,29 +131,38 @@ export async function add(effectName, options = {}) {
       console.log(chalk.dim(`  ${file.targetPath}`));
     });
 
-    if (!options.yes) {
-      const { proceed } = await prompts(
-        {
-          type: "confirm",
-          name: "proceed",
-          message: "Overwrite existing files?",
-          initial: false,
-        },
-        {
-          onCancel: () => {
-            console.log();
-            console.log(chalk.yellow("Installation cancelled."));
-            process.exit(0);
-          },
-        }
+    if (options.yes) {
+      console.log();
+      console.log(
+        chalk.yellow(
+          "Skipping — re-run with --overwrite to replace existing files."
+        )
       );
+      console.log();
+      return;
+    }
 
-      if (!proceed) {
-        console.log();
-        console.log(chalk.yellow("Installation cancelled."));
-        console.log();
-        process.exit(0);
+    const { proceed } = await prompts(
+      {
+        type: "confirm",
+        name: "proceed",
+        message: "Overwrite existing files?",
+        initial: false,
+      },
+      {
+        onCancel: () => {
+          console.log();
+          console.log(chalk.yellow("Installation cancelled."));
+          process.exit(0);
+        },
       }
+    );
+
+    if (!proceed) {
+      console.log();
+      console.log(chalk.yellow("Installation cancelled."));
+      console.log();
+      process.exit(0);
     }
   }
 
@@ -328,18 +336,6 @@ function recordLocalInstall(effectName, cwd) {
   };
 
   writeConfig(currentConfig, cwd);
-}
-
-async function getFileContent(file) {
-  if (file.type === "registry:asset" && file.source && !file.content) {
-    return fetchRegistryAsset(file.source);
-  }
-
-  if (file.encoding === "base64") {
-    return Buffer.from(file.content, "base64");
-  }
-
-  return file.content || "";
 }
 
 function getImportPath(file, config) {

--- a/packages/cli/src/tests/add-overwrite.test.js
+++ b/packages/cli/src/tests/add-overwrite.test.js
@@ -32,6 +32,10 @@ vi.mock("prompts", () => ({ default: (...args) => promptsMock(...args) }));
 vi.mock("../utils/config.js", () => ({
   configExists: () => true,
   readConfig: () => ({ aliases: { effects: "@/components/effects" } }),
+  writeConfig: () => {},
+  detectProjectEnvironment: () => "react",
+  detectNextRouter: () => null,
+  hasTailwindInstalled: () => true,
 }));
 
 vi.mock("../utils/auth.js", () => ({
@@ -41,6 +45,7 @@ vi.mock("../utils/auth.js", () => ({
 vi.mock("../utils/package-manager.js", () => ({
   getMissingDependencies: () => [],
   installDependencies: () => {},
+  detectPackageManager: () => "npm",
 }));
 
 vi.mock("../utils/lockfile.js", () => ({

--- a/packages/cli/src/utils/registry.js
+++ b/packages/cli/src/utils/registry.js
@@ -313,6 +313,18 @@ export async function fetchRegistryAsset(source) {
   return Buffer.from(await response.arrayBuffer());
 }
 
+export async function getFileContent(file) {
+  if (file.type === "registry:asset" && file.source && !file.content) {
+    return fetchRegistryAsset(file.source);
+  }
+
+  if (file.encoding === "base64") {
+    return Buffer.from(file.content, "base64");
+  }
+
+  return file.content || "";
+}
+
 export function getRegistryItemFiles(item, config, cwd = process.cwd()) {
   const usesSrc = fs.existsSync(path.join(cwd, "src"));
   const prefix = usesSrc ? "src/" : "";


### PR DESCRIPTION
## Summary
- **Critical fix**: `registry.js` had lost its exported `getFileContent`, while `diff.js` still imported it. Since `index.js` imports `diff.js` eagerly, this broke **every** CLI invocation (`--version`, `--help`, `add`, `init`, bare `hyperiux`) with a `SyntaxError` at module-load time. Confirmed via `npm link` and direct execution of the real linked binary - all crashed identically before the fix, all work after.
- Root cause looks like a merge-integration gap rather than a mistake in any single branch: `diff.js` doesn't exist at all on the `vidushi` branch, so it came from a different lineage than the `registry.js` it landed next to on `main` - individual branch testing (including via `npm link`, which the team did use) would never have surfaced this, only testing the merged result would.
- Restored `getFileContent` in `registry.js` (next to `fetchRegistryAsset`, which it depends on) and pointed `add.js` at the shared export instead of its own private duplicate.
- Fixed `add-overwrite.test.js`'s manual mocks for `config.js`/`package-manager.js`, which were missing several exports `add.js` now legitimately calls (`detectProjectEnvironment`, `detectNextRouter`, `hasTailwindInstalled`, `writeConfig`, `detectPackageManager`).
- Getting those mocks correct surfaced a **second, genuine pre-existing bug**: `add --yes` (no `--overwrite`) on a project with existing customized files silently proceeded to overwrite them instead of skipping - the interactive-prompt guard was skipped for `--yes` but nothing replaced it. Now exits cleanly with a message pointing at `--overwrite`.

## Test plan
- [x] `npx vitest run` in `packages/cli` - 47/47 passing (was 5 failing before this fix)
- [x] `npx eslint src` - clean
- [x] `npm link` + real invocation of the linked global binary: `hyperiux --version`, `--help`, `add`, `init`, bare `hyperiux` all work
- [x] End-to-end live test against the real registry (not mocks): `hyperiux init --yes` in a scratch React/Vite project (correctly detects framework, flags missing import alias, auto-configures it), `hyperiux add dotted-grid --yes` (writes files successfully), customize the file, re-run `add --yes` (correctly skips, leaves the customization untouched)
- [ ] CI green on this PR