### PR TITLE
Add Glama server maintainers

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["hitesh-bhardwaj", "hyperiux"]
+}


### PR DESCRIPTION
Adds Glama ownership metadata for the Hyperiux MCP Server.\n\nThis authorizes both @hitesh-bhardwaj and @hyperiux to claim and manage the organization-owned server listing on Glama.